### PR TITLE
Avoid 'warning: "CFG80211_DEL_STA_V2" redefined' Messages

### DIFF
--- a/CORE/HDD/inc/wlan_hdd_cfg80211.h
+++ b/CORE/HDD/inc/wlan_hdd_cfg80211.h
@@ -2928,7 +2928,9 @@ v_U8_t* wlan_hdd_cfg80211_get_ie_ptr(const v_U8_t *pIes,
                                      int length,
                                      v_U8_t eid);
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0))
+#if !defined(CFG80211_DEL_STA_V2)
 #define CFG80211_DEL_STA_V2
+#endif
 #endif
 
 #ifdef CFG80211_DEL_STA_V2


### PR DESCRIPTION
The `CFG80211_DEL_STA_V2` symbol was introduced in later stable and mainline Linux kernels, in DEY Linux kernels, the `CFG80211_DEL_STA_V2` symbol may already be back-ported and defined.