### PR TITLE
Respect and Use the Value for WLAN_ROOT Consistently and Pervasively

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ KBUILD_OPTIONS += WLAN_OPEN_SOURCE=$(WLAN_OPEN_SOURCE)
 KBUILD_OPTIONS += $(KBUILD_EXTRA) # Extra config if any
 
 all:
-	$(MAKE) -C $(KERNEL_SRC) M=$(shell pwd) modules $(KBUILD_OPTIONS)
+	$(MAKE) -C $(KERNEL_SRC) M=$(WLAN_ROOT) modules $(KBUILD_OPTIONS)
 
 modules_install:
-	$(MAKE) INSTALL_MOD_STRIP=1 -C $(KERNEL_SRC) M=$(shell pwd) modules_install
+	$(MAKE) INSTALL_MOD_STRIP=1 -C $(KERNEL_SRC) M=$(WLAN_ROOT) modules_install
 
 clean:
-	$(MAKE) -C $(KERNEL_SRC) M=$(PWD) clean
+	$(MAKE) -C $(KERNEL_SRC) M=$(WLAN_ROOT) clean


### PR DESCRIPTION
The variable `WLAN_ROOT` is intended to point at the root of the project source tree and the location of _Kbuild_, which is what the build Linux expects `M` to be set to.

Consequently, use the value for `WLAN_ROOT` consistently and pervasively everywhere `M` is set and passed to the Linux build.

In particular, `PWD` will be incorrect if make is invoked with `-C` and `$(shell pwd)` may be in conflict with a value of `WLAN_ROOT` asserted in the environment.